### PR TITLE
Remove default domain value (BREAKING CHANGE)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,7 @@
 # CLAUDE.md - Guidelines for Policy Action
 
 ## Commands
+
 - `npm run test` - Run all tests with coverage
 - `npm run test -- -t "test name"` - Run specific test
 - `npm run format:write` - Format code with Prettier
@@ -9,7 +10,8 @@
 - `npm run package` - Build the action
 
 ## Style Guidelines
-- **Language**: JavaScript ES2023, Node.js >=22
+
+- **Language**: JavaScript ECMAScript 2023, Node.js >=22
 - **Formatting**: Prettier, enforce with `npm run format:write`
 - **Linting**: ESLint with GitHub plugin, enforce with `npm run lint`
 - **Error Handling**: Use try/catch blocks with specific error handling
@@ -18,16 +20,19 @@
 - **Testing**: Jest with 100% coverage target
 
 ## Naming Conventions
+
 - camelCase for variables, functions, methods
 - PascalCase for classes
 - Clear descriptive names, no abbreviations
 
 ## Code Structure
+
 - Keep functions small and single-purpose
 - Handle errors explicitly with appropriate messaging
 - Follow GitHub Actions best practices for input/output
 
 ## Security
+
 - Always treat user inputs as untrusted
 - Mark secrets with core.setSecret()
 - Validate all inputs before use

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,33 @@
+# CLAUDE.md - Guidelines for Policy Action
+
+## Commands
+- `npm run test` - Run all tests with coverage
+- `npm run test -- -t "test name"` - Run specific test
+- `npm run format:write` - Format code with Prettier
+- `npm run lint` - Run ESLint checks
+- `npm run all` - Format, lint, test and package
+- `npm run package` - Build the action
+
+## Style Guidelines
+- **Language**: JavaScript ES2023, Node.js >=22
+- **Formatting**: Prettier, enforce with `npm run format:write`
+- **Linting**: ESLint with GitHub plugin, enforce with `npm run lint`
+- **Error Handling**: Use try/catch blocks with specific error handling
+- **Imports**: CommonJS (require/module.exports)
+- **Documentation**: JSDoc for functions
+- **Testing**: Jest with 100% coverage target
+
+## Naming Conventions
+- camelCase for variables, functions, methods
+- PascalCase for classes
+- Clear descriptive names, no abbreviations
+
+## Code Structure
+- Keep functions small and single-purpose
+- Handle errors explicitly with appropriate messaging
+- Follow GitHub Actions best practices for input/output
+
+## Security
+- Always treat user inputs as untrusted
+- Mark secrets with core.setSecret()
+- Validate all inputs before use

--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@ steps:
 
   - name: SGNL Policy Check
     id: sgnl
-    uses: SGNL-ai/policy-action@v1
+    uses: SGNL-ai/policy-action@v2
     with:
+      domain: ${{ vars.SGNL_SUBDOMAIN }}.sgnlapis.cloud
       token: ${{ secrets.SGNL_TOKEN }}
       principalId: ${{ github.actor }}
       action: 'my action'
@@ -78,24 +79,24 @@ Tests are using [Jest](https://jestjs.io/)
 After a release is merged, the release has to be tagged so other projects can
 use it correctly.
 
-> [!NOTE] Example: You are releasing a backwards compatible feature to the v1
-> major release. Let's assume the next release is v1.4.0 (i.e. not a patch, not
+> [!NOTE] Example: You are releasing a backwards compatible feature to the v2
+> major release. Let's assume the next release is v2.1.0 (i.e. not a patch, not
 > a breaking change) then you would do the following to create the tags:
 
-Updating the existing v1 tag so existing workflows can take advantage of your
+Updating the existing v2 tag so existing workflows can take advantage of your
 new feature
 
-`git tag -s -f -m "update v1 tag" v1`
+`git tag -s -f -m "update v2 tag" v2`
 
 Create a new tag to track your new feature more specifically
 
-`git tag -s -m "update v1.1.0 tag" v1.1.0`
+`git tag -s -m "update v2.1.0 tag" v2.1.0`
 
-Or, if you are just patching a bug against v1.1, create a patch tag for a bugfix
+Or, if you are just patching a bug against v2.0, create a patch tag for a bugfix
 
-`git tag -s -m "create v1.1.1 tag" v1.1.1`
+`git tag -s -m "create v2.0.1 tag" v2.0.1`
 
-Push the tags up to GitHub. The `-f` is required to update the v1 tag
+Push the tags up to GitHub. The `-f` is required to update the v2 tag
 
 `git push --tags --force`
 

--- a/__tests__/main.test.js
+++ b/__tests__/main.test.js
@@ -162,8 +162,8 @@ describe('action', () => {
   // test domain parameter is passed correctly
   it('passes domain parameter to Query constructor', async () => {
     inputs.domain = 'abc.sgnlapis.cloud'
-    
-    sgnl.mockImplementation((query) => {
+
+    sgnl.mockImplementation(query => {
       // Verify query object received the correct domain
       expect(query.domain).toBe('abc.sgnlapis.cloud')
       expect(query.endpoint()).toContain('https://abc.sgnlapis.cloud')

--- a/__tests__/main.test.js
+++ b/__tests__/main.test.js
@@ -159,6 +159,21 @@ describe('action', () => {
     expect(setFailedMock).not.toHaveBeenCalled()
   })
 
+  // test domain parameter is passed correctly
+  it('passes domain parameter to Query constructor', async () => {
+    inputs.domain = 'abc.sgnlapis.cloud'
+    
+    sgnl.mockImplementation((query) => {
+      // Verify query object received the correct domain
+      expect(query.domain).toBe('abc.sgnlapis.cloud')
+      expect(query.endpoint()).toContain('https://abc.sgnlapis.cloud')
+      return { decision: true }
+    })
+
+    await main.run()
+    expect(sgnl).toHaveBeenCalled()
+  })
+
   // throw 401 exception
   it('fails job on non-200 error', async () => {
     sgnl.mockImplementation(() => {

--- a/action.yml
+++ b/action.yml
@@ -4,8 +4,7 @@ description: Calls SGNL for a policy check. Also see https://developer.sgnl.ai/
 inputs:
   domain:
     required: true
-    description: The SGNL API hostname.
-    default: access.sgnlapis.cloud
+    description: The SGNL API hostname -> {subdomain}.sgnlapis.cloud
   token:
     required: true
     description:


### PR DESCRIPTION
## Summary
- Remove default value for domain parameter, requiring it to be explicitly provided
- Add test to verify domain parameter is passed correctly
- Update README.md to show v2 usage with domain parameter from repository variable
- Update versioning examples in README to reference v2 instead of v1

## Breaking Change
This is a breaking change that removes the default value for the domain parameter (`access.sgnlapis.cloud`). Users will now need to explicitly provide the domain value when using the action.

This change supports the new subdomain style and should be tagged as v2.0.0 when merged.

## Test plan
- All tests pass, including new test for domain parameter
- Package builds successfully
- README.md updated with correct usage examples

🤖 Generated with [Claude Code](https://claude.ai/code)