### PR TITLE
Fix dependabot workflow condition for app/dependabot actor

### DIFF
--- a/.github/workflows/dependabot-rebuild.yml
+++ b/.github/workflows/dependabot-rebuild.yml
@@ -9,7 +9,7 @@ permissions: {}
 
 jobs:
   rebuild-and-approve:
-    if: github.actor == 'dependabot[bot]'
+    if: github.actor == 'dependabot[bot]' || github.actor == 'app/dependabot'
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
The dependabot automation workflow was not triggering because the actor is 'app/dependabot', not 'dependabot[bot]'. This fixes the condition to handle both formats.