### PR TITLE
Use commit amend for dist updates to fix status check alignment

### DIFF
--- a/.github/workflows/dist-management.yml
+++ b/.github/workflows/dist-management.yml
@@ -71,10 +71,10 @@ jobs:
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           git add dist/
-          git commit -m "chore: update dist files"
-          git push
+          git commit --amend --no-edit
+          git push --force
           echo "updated=true" >> "$GITHUB_OUTPUT"
-          echo "✅ Dist files updated and committed"
+          echo "✅ Dist files updated via commit amend"
 
       - name: Auto-approve Dependabot PRs
         if:


### PR DESCRIPTION
## Summary
- Changes dist-management workflow to use `git commit --amend` instead of creating new commits
- Ensures status checks align with PR branch protection by maintaining the same commit SHA
- Fixes the issue where workflows run against different commits than PR protection checks

## The Problem
With the current approach:
1. PR created at commit `ABC123`
2. Dist management creates new commit `DEF456` with updated dist files
3. Workflows run against `DEF456` 
4. PR branch protection checks `ABC123`
5. Status checks don't align ❌

## The Solution  
With commit amend:
1. PR created at commit `ABC123`
2. Dist management amends `ABC123` with updated dist files (same SHA)
3. Workflows run against amended `ABC123`
4. PR branch protection checks `ABC123` 
5. Status checks align perfectly ✅

## Key Changes
- `git commit --amend --no-edit` instead of `git commit -m "..."`
- `git push --force` required since we're rewriting pushed history
- Cleaner git history (no extra "chore: update dist" commits)

## Test Plan
- [ ] Merge this PR
- [ ] Test with recreated Dependabot PR
- [ ] Verify status checks appear correctly on PR

🤖 Generated with [Claude Code](https://claude.ai/code)