### PR TITLE
Fix GitHub App token action version to v2

### DIFF
--- a/.github/workflows/dist-management.yml
+++ b/.github/workflows/dist-management.yml
@@ -67,7 +67,7 @@ jobs:
         if:
           steps.diff.outputs.has_changes == 'true' && github.event_name ==
           'pull_request'
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v2
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}


### PR DESCRIPTION
Updates actions/create-github-app-token from v1 to v2 to fix the workflow error.

This fixes the error in the dist-management workflow:
`Error: Input required and not supplied: app-id`

🤖 Generated with [Claude Code](https://claude.ai/code)