### PR TITLE
Fix Git authentication to use GitHub App token

### DIFF
--- a/.github/workflows/dist-management.yml
+++ b/.github/workflows/dist-management.yml
@@ -80,13 +80,12 @@ jobs:
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
+          git config --local http.https://github.com/.extraheader "AUTHORIZATION: bearer ${{ steps.app_token.outputs.token }}"
           git add dist/
           git commit -m "chore: update dist files"
           git push
           echo "updated=true" >> "$GITHUB_OUTPUT"
           echo "✅ Dist files updated and committed"
-        env:
-          GITHUB_TOKEN: ${{ steps.app_token.outputs.token }}
 
       - name: Auto-approve Dependabot PRs
         if:


### PR DESCRIPTION
Configures Git to use the GitHub App token for push operations so that commits made by the workflow can trigger subsequent workflows.

This fixes the issue where commits were being made by `actions-user` instead of the GitHub App, preventing workflow triggers.

🤖 Generated with [Claude Code](https://claude.ai/code)